### PR TITLE
First iteration of confidence score

### DIFF
--- a/project/backend/src/main/java/com/google/sps/data/RestaurantScorer.java
+++ b/project/backend/src/main/java/com/google/sps/data/RestaurantScorer.java
@@ -6,6 +6,7 @@ import org.json.JSONObject;
 public final class RestaurantScorer {
   private static final int MAX_RATING = 5;
   private static final int MID_RATING = 3;
+  private static final int NUM_INITIAL_RATINGS = 20;
   /** Class should not be instantiated. */
   private RestaurantScorer() {}
 
@@ -28,9 +29,17 @@ public final class RestaurantScorer {
     // MID_RATING.
     boolean hasRating = restaurantRating != -1;
     if (hasRating) {
-      score += (restaurantRating / MAX_RATING) - (MID_RATING / MAX_RATING);
+      score += calculateRatingScore(restaurantRating, restaurant.getNumRatings());
     }
     double percentMatch = score / maxPoints;
     return percentMatch;
+  }
+
+  /** Skews ratings so that ratings with a lower number of ratings are weighed less. */
+  private static double calculateRatingScore(double avgRating, int numRatings) {
+    int totalRatings = NUM_INITIAL_RATINGS + numRatings;
+    double totalPoints = NUM_INITIAL_RATINGS * MID_RATING + avgRating * numRatings;
+    double weightedRating = totalPoints / totalRatings;
+    return (weightedRating - MID_RATING) / MAX_RATING;
   }
 }

--- a/project/backend/src/main/java/com/google/sps/data/RestaurantScorer.java
+++ b/project/backend/src/main/java/com/google/sps/data/RestaurantScorer.java
@@ -6,6 +6,8 @@ import org.json.JSONObject;
 public final class RestaurantScorer {
   private static final int MAX_RATING = 5;
   private static final int MID_RATING = 3;
+  // Number of "dummy ratings" that will be used to calculate the rating score.
+  // Arbitrary value will be replaced by a value based on the average num ratings.
   private static final int NUM_INITIAL_RATINGS = 20;
   /** Class should not be instantiated. */
   private RestaurantScorer() {}


### PR DESCRIPTION
- Skews ratings so that ratings with fewer ratings are weighed less.
- Starts off with NUM_INITIAL_RATINGS "fake ratings" that are worth the MID_RATING value.
- So, the less ratings there are, the more they will be skewed towards MID_RATING.
- Since restaurants with exactly MID_RATING do not affect the score, this effectively gives a lower weight to restaurants with fewer ratings.

Biggest area for improvement: NUM_INITIAL_RATINGS is completely arbitrary right now. It should ideally be based on the average number of ratings that each place we are looking at has (it's value should be less than the average but still based on the average). *note that this number does not actually represent ratings that exist