### PR TITLE
Add location finder to modal using Geocoder

### DIFF
--- a/project/frontend/public/index.html
+++ b/project/frontend/public/index.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Crimson+Text:400,700|Montserrat:100,400,700,900">
     <link rel="preload" as="image" href="%PUBLIC_URL%/food-background-small.jpg">
     <script src="https://apis.google.com/js/platform.js" defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_API_KEY%&libraries=places"></script>
     <title>Restaurant Finder</title>
   </head>
   <body>

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+class LocationFinder extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      locationString: '',
+    };
+    this.changeState = this.changeState.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  changeState(event) {
+    this.setState({ locationString: event.target.value });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    this.getLocation(this.state.locationString);
+  }
+
+  getLocation(userInput) {
+    const proxyUrl = 'https://cors-anywhere.herokuapp.com/';
+    const geocodeBaseUrl = 'https://maps.googleapis.com/maps/api/geocode/json?';
+    const searchParams = new URLSearchParams();
+    searchParams.append('address', userInput);
+    searchParams.append('key', process.env.REACT_APP_GOOGLE_API_KEY);
+    fetch(proxyUrl + geocodeBaseUrl + searchParams, {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((location) => {
+        if (!location) {
+          alert('Could not find any results for that location.');
+          return;
+        }
+        const currLocation = location.results[0].geometry.location;
+        const locationName = location.results[0].formatted_address;
+        this.props.sendData({ currLocation, locationName, });
+      });
+  }
+
+  render() {
+    return(
+      <form onSubmit={this.handleSubmit}>
+        <input
+          name='location'
+          onChange={this.changeState}
+        />
+        <button onClick={this.handleSubmit}>Find Location</button>
+      </form>
+    );
+  }
+  
+}
+export default LocationFinder;

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -18,7 +18,10 @@ class LocationFinder extends React.Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    this.getLocation(this.state.userInput);
+    const locationData = this.getLocation(this.state.userInput);
+    if (locationData) {
+      this.props.sendData(locationData);
+    }
   }
 
   getLocation(userInput) {
@@ -35,15 +38,16 @@ class LocationFinder extends React.Component {
     })
       .then((response) => response.json())
       .then((location) => {
-        if (!location) {
+        if (location.error_message) {
           alert('Could not find any results for that location.');
-          return;
+          return false;
         }
         const currLocation = location.results[0].geometry.location;
         const locationName = location.results[0].formatted_address;
         this.setState({ locationName });
         this.setState({ submitted: true });
-        this.props.sendData({ currLocation, locationName });
+        
+        return { currLocation, locationName };
       });
   }
 

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -33,8 +33,7 @@ class LocationFinder extends React.Component {
         geocoder.geocode({ location: currLocation }, (results, status) => {
           if (status === 'OK') {
             const locationName = results[0].formatted_address;
-            this.setState({ locationName });
-            this.setState({ submitted: true });
+            this.setState({ locationName, submitted: true });
             this.props.sendData({ currLocation, locationName });
           } else {
             alert(
@@ -66,8 +65,7 @@ class LocationFinder extends React.Component {
           lng: results[0].geometry.location.lng(),
         };
         const locationName = results[0].formatted_address;
-        this.setState({ locationName });
-        this.setState({ submitted: true });
+        this.setState({ locationName, submitted: true });
         this.props.sendData({ currLocation, locationName });
       } else {
         alert('Geocode was not successful for the following reason: ' + status);

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -39,21 +39,17 @@ class LocationFinder extends React.Component {
         }
         const currLocation = location.results[0].geometry.location;
         const locationName = location.results[0].formatted_address;
-        this.props.sendData({ currLocation, locationName, });
+        this.props.sendData({ currLocation, locationName });
       });
   }
 
   render() {
-    return(
+    return (
       <form onSubmit={this.handleSubmit}>
-        <input
-          name='location'
-          onChange={this.changeState}
-        />
+        <input name='location' onChange={this.changeState} />
         <button onClick={this.handleSubmit}>Find Location</button>
       </form>
     );
   }
-  
 }
 export default LocationFinder;

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -4,7 +4,9 @@ class LocationFinder extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      locationString: '',
+      userInput: '',
+      locationName: '',
+      submitted: false,
     };
     this.changeState = this.changeState.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -16,7 +18,7 @@ class LocationFinder extends React.Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    this.getLocation(this.state.locationString);
+    this.getLocation(this.state.userInput);
   }
 
   getLocation(userInput) {
@@ -39,16 +41,21 @@ class LocationFinder extends React.Component {
         }
         const currLocation = location.results[0].geometry.location;
         const locationName = location.results[0].formatted_address;
+        this.setState({ locationName });
+        this.setState({ submitted: true });
         this.props.sendData({ currLocation, locationName });
       });
   }
 
   render() {
     return (
-      <form onSubmit={this.handleSubmit}>
-        <input name='locationString' onChange={this.changeState} />
-        <button onClick={this.handleSubmit}>Find Location</button>
-      </form>
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <input name='userInput' onChange={this.changeState} />
+          <button onClick={this.handleSubmit}>Find Location</button>
+        </form>
+        {this.state.submitted ? <p>Your current location: {this.state.locationName}</p> : null}
+      </div>
     );
   }
 }

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -30,25 +30,20 @@ class LocationFinder extends React.Component {
 
   geolocate() {
     if (navigator.geolocation) {
+      const google = window.google;
+      const geocoder = new google.maps.Geocoder();
       navigator.geolocation.getCurrentPosition((position) => {
         const currLocation = { lat: position.coords.latitude, lng: position.coords.longitude };
-        const proxyUrl = 'https://cors-anywhere.herokuapp.com/';
-        const geolocationBaseUrl = 'https://maps.googleapis.com/maps/api/geocode/json?';
-        const searchParams = new URLSearchParams();
-        searchParams.append('latlng', currLocation.lat + ',' + currLocation.lng);
-        searchParams.append('key', process.env.REACT_APP_GOOGLE_API_KEY);
-        fetch(proxyUrl + geolocationBaseUrl + searchParams)
-          .then((response) => response.json())
-          .then((data) => {
-            if (data.results) {
-              const locationName = data.results[0].formatted_address;
-              this.setState({ locationName });
-              this.setState({ submitted: true });
-              this.props.sendData({ currLocation, locationName });
-            } else {
-              alert('Cannot find your location');
-            }
-          });
+        geocoder.geocode({ location: currLocation }, (results, status) => {
+          if (status == 'OK') {
+            const locationName = results[0].formatted_address;
+            this.setState({ locationName });
+            this.setState({ submitted: true });
+            this.props.sendData({ currLocation, locationName });
+          } else {
+            alert('Geocode was not successful for the following reason: ' + status);
+          }
+        });
       });
     } else {
       alert('Cannot find your location');

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -11,7 +11,7 @@ class LocationFinder extends React.Component {
   }
 
   changeState(event) {
-    this.setState({ locationString: event.target.value });
+    this.setState({ [event.target.name]: event.target.value });
   }
 
   handleSubmit(event) {
@@ -46,7 +46,7 @@ class LocationFinder extends React.Component {
   render() {
     return (
       <form onSubmit={this.handleSubmit}>
-        <input name='location' onChange={this.changeState} />
+        <input name='locationString' onChange={this.changeState} />
         <button onClick={this.handleSubmit}>Find Location</button>
       </form>
     );

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -17,7 +17,7 @@ class LocationFinder extends React.Component {
     this.setState({ [event.target.name]: event.target.value });
   }
 
-  /** 
+  /**
    * Uses Geolocation to get the user's current coordinates.
    * Gets formatted address to display from Geocoder.
    */
@@ -26,7 +26,10 @@ class LocationFinder extends React.Component {
       const google = window.google;
       const geocoder = new google.maps.Geocoder();
       navigator.geolocation.getCurrentPosition((position) => {
-        const currLocation = { lat: position.coords.latitude, lng: position.coords.longitude };
+        const currLocation = {
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        };
         geocoder.geocode({ location: currLocation }, (results, status) => {
           if (status === 'OK') {
             const locationName = results[0].formatted_address;
@@ -34,12 +37,18 @@ class LocationFinder extends React.Component {
             this.setState({ submitted: true });
             this.props.sendData({ currLocation, locationName });
           } else {
-            alert('Geocode was not successful for the following reason: ' + status);
+            alert(
+              'Geocode was not successful for the following reason: ' +
+                status +
+                '. Try entering a location in the text box below.'
+            );
           }
         });
       });
     } else {
-      alert('Cannot find your location');
+      alert(
+        'Cannot find your location. Try entering a location in the text box below.'
+      );
     }
   }
 
@@ -52,10 +61,10 @@ class LocationFinder extends React.Component {
     const geocoder = new google.maps.Geocoder();
     geocoder.geocode({ address: this.state.userInput }, (results, status) => {
       if (status === 'OK') {
-        const currLocation = { 
-          lat: results[0].geometry.location.lat(), 
+        const currLocation = {
+          lat: results[0].geometry.location.lat(),
           lng: results[0].geometry.location.lng(),
-         };
+        };
         const locationName = results[0].formatted_address;
         this.setState({ locationName });
         this.setState({ submitted: true });
@@ -69,7 +78,9 @@ class LocationFinder extends React.Component {
   render() {
     return (
       <div>
-        <button onClick={this.getLocationFromGeolocate}>Use My Current Location</button>
+        <button onClick={this.getLocationFromGeolocate}>
+          Use My Current Location
+        </button>
         <form id='get-input-location-form' onSubmit={this.getLocationFromText}>
           <input name='userInput' onChange={this.changeState} />
           <button type='submit'>Find Location</button>

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -9,33 +9,27 @@ class LocationFinder extends React.Component {
       submitted: false,
     };
     this.changeState = this.changeState.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.geolocate = this.geolocate.bind(this);
-    this.getLocation = this.getLocation.bind(this);
+    this.getLocationFromGeolocate = this.getLocationFromGeolocate.bind(this);
+    this.getLocationFromText = this.getLocationFromText.bind(this);
   }
 
   changeState(event) {
     this.setState({ [event.target.name]: event.target.value });
   }
 
-  handleSubmit(event) {
+  /** 
+   * Uses Geolocation to get the user's current coordinates.
+   * Gets formatted address to display from Geocoder.
+   */
+  getLocationFromGeolocate(event) {
     event.preventDefault();
-    this.getLocation(this.state.userInput, (locationData) => {
-      if (locationData) {
-        this.props.sendData(locationData);
-      }
-    });
-    
-  }
-
-  geolocate() {
     if (navigator.geolocation) {
       const google = window.google;
       const geocoder = new google.maps.Geocoder();
       navigator.geolocation.getCurrentPosition((position) => {
         const currLocation = { lat: position.coords.latitude, lng: position.coords.longitude };
         geocoder.geocode({ location: currLocation }, (results, status) => {
-          if (status == 'OK') {
+          if (status === 'OK') {
             const locationName = results[0].formatted_address;
             this.setState({ locationName });
             this.setState({ submitted: true });
@@ -50,10 +44,14 @@ class LocationFinder extends React.Component {
     }
   }
 
-  getLocation(userInput, callback) {
+  /**
+   * Uses Geocoder to get location information based on user input.
+   */
+  getLocationFromText(event) {
+    event.preventDefault();
     const google = window.google;
     const geocoder = new google.maps.Geocoder();
-    geocoder.geocode({ address: userInput }, (results, status) => {
+    geocoder.geocode({ address: this.state.userInput }, (results, status) => {
       if (status === 'OK') {
         const currLocation = { 
           lat: results[0].geometry.location.lat(), 
@@ -62,7 +60,7 @@ class LocationFinder extends React.Component {
         const locationName = results[0].formatted_address;
         this.setState({ locationName });
         this.setState({ submitted: true });
-        callback({ currLocation, locationName });
+        this.props.sendData({ currLocation, locationName });
       } else {
         alert('Geocode was not successful for the following reason: ' + status);
       }
@@ -72,10 +70,12 @@ class LocationFinder extends React.Component {
   render() {
     return (
       <div>
-        <button onClick={this.geolocate}>Use My Current Location</button>
-        <form onSubmit={this.handleSubmit}>
+        <form  id='get-curr-location-form' onSubmit={this.getLocationFromGeolocate}>
+          <button type='submit'>Use My Current Location</button>
+        </form>
+        <form id='get-input-location-form' onSubmit={this.getLocationFromText}>
           <input name='userInput' onChange={this.changeState} />
-          <button onClick={this.handleSubmit}>Find Location</button>
+          <button type='submit'>Find Location</button>
         </form>
         {this.state.submitted ? (
           <p>Your current location: {this.state.locationName}</p>

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -54,7 +54,9 @@ class LocationFinder extends React.Component {
           <input name='userInput' onChange={this.changeState} />
           <button onClick={this.handleSubmit}>Find Location</button>
         </form>
-        {this.state.submitted ? <p>Your current location: {this.state.locationName}</p> : null}
+        {this.state.submitted ? (
+          <p>Your current location: {this.state.locationName}</p>
+        ) : null}
       </div>
     );
   }

--- a/project/frontend/src/components/LocationFinder.js
+++ b/project/frontend/src/components/LocationFinder.js
@@ -21,8 +21,7 @@ class LocationFinder extends React.Component {
    * Uses Geolocation to get the user's current coordinates.
    * Gets formatted address to display from Geocoder.
    */
-  getLocationFromGeolocate(event) {
-    event.preventDefault();
+  getLocationFromGeolocate() {
     if (navigator.geolocation) {
       const google = window.google;
       const geocoder = new google.maps.Geocoder();
@@ -70,9 +69,7 @@ class LocationFinder extends React.Component {
   render() {
     return (
       <div>
-        <form  id='get-curr-location-form' onSubmit={this.getLocationFromGeolocate}>
-          <button type='submit'>Use My Current Location</button>
-        </form>
+        <button onClick={this.getLocationFromGeolocate}>Use My Current Location</button>
         <form id='get-input-location-form' onSubmit={this.getLocationFromText}>
           <input name='userInput' onChange={this.changeState} />
           <button type='submit'>Find Location</button>

--- a/project/frontend/src/components/PreferenceForm.js
+++ b/project/frontend/src/components/PreferenceForm.js
@@ -73,9 +73,10 @@ class PreferenceForm extends React.Component {
   handleSubmit(event) {
     event.preventDefault();
     const { currLocation } = this.state;
-    currLocation['lat'] = this.props.history.location.currLocation.lat;
-    currLocation['lng'] = this.props.history.location.currLocation.lng;
+    currLocation['lat'] = this.props.currLocation.lat;
+    currLocation['lng'] = this.props.currLocation.lng;
     this.setState({ currLocation });
+    console.log(this.state);
     this.props.history.push({
       pathname: '/match-results',
       state: this.state,
@@ -98,7 +99,7 @@ class PreferenceForm extends React.Component {
     const prices = { Low: 1, Medium: 2, High: 3, 'Very High': 4 };
     return (
       <form onSubmit={this.handleSubmit}>
-        <p>Your current location: {this.props.history.location.locationName}</p>
+        <p>Your current location: {this.props.locationName}</p>
         <label htmlFor='cuisine'>
           What cuisine?
           <select

--- a/project/frontend/src/components/PreferenceForm.js
+++ b/project/frontend/src/components/PreferenceForm.js
@@ -103,8 +103,8 @@ class PreferenceForm extends React.Component {
     const prices = { Low: 1, Medium: 2, High: 3, 'Very High': 4 };
     return (
       <form onSubmit={this.handleSubmit}>
-        <label htmlFor='location-finder'>Search for your location here</label>
-        <LocationFinder sendData={this.getLocationData} />
+        <label htmlFor='location-finder'>Search for your location here
+        <LocationFinder sendData={this.getLocationData} /></label>
         <label htmlFor='cuisine'>
           What cuisine?
           <select

--- a/project/frontend/src/components/PreferenceForm.js
+++ b/project/frontend/src/components/PreferenceForm.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import LocationFinder from './LocationFinder.js';
 
 import { Slider } from 'rsuite';
 
@@ -27,6 +28,7 @@ class PreferenceForm extends React.Component {
     };
     this.changeState = this.changeState.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.getData = this.getData.bind(this);
   }
 
   // Updates the state of the input element so it holds the chosen value.
@@ -54,6 +56,10 @@ class PreferenceForm extends React.Component {
     const field = this.state[attrName];
     field['weight'] = value;
     this.setState({ [attrName]: field });
+  }
+
+  getData(data) {
+    this.setState({ currLocation: data.currLocation });
   }
 
   getSlider(attrName) {
@@ -97,6 +103,8 @@ class PreferenceForm extends React.Component {
     const prices = { Low: 1, Medium: 2, High: 3, 'Very High': 4 };
     return (
       <form onSubmit={this.handleSubmit}>
+        <label htmlFor='location-finder'>Search for your location here</label>
+        <LocationFinder sendData={this.getData} />
         <label htmlFor='cuisine'>
           What cuisine?
           <select
@@ -164,28 +172,6 @@ class PreferenceForm extends React.Component {
           <br />
           Importance
           {this.getSlider('priceLevel')}
-        </label>
-        <label htmlFor='lat'>
-          Latitude
-          <input
-            type='number'
-            id='lat'
-            name='currLocation'
-            value={this.state.lat}
-            onChange={this.changeState}
-            required
-          />
-        </label>
-        <label htmlFor='lng'>
-          Longitude
-          <input
-            type='number'
-            id='lng'
-            name='currLocation'
-            value={this.state.lng}
-            onChange={this.changeState}
-            required
-          />
         </label>
         <label htmlFor='open'>
           Open Now?

--- a/project/frontend/src/components/PreferenceForm.js
+++ b/project/frontend/src/components/PreferenceForm.js
@@ -28,7 +28,7 @@ class PreferenceForm extends React.Component {
     };
     this.changeState = this.changeState.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.getData = this.getData.bind(this);
+    this.getLocationData = this.getLocationData.bind(this);
   }
 
   // Updates the state of the input element so it holds the chosen value.
@@ -58,7 +58,7 @@ class PreferenceForm extends React.Component {
     this.setState({ [attrName]: field });
   }
 
-  getData(data) {
+  getLocationData(data) {
     this.setState({ currLocation: data.currLocation });
   }
 
@@ -104,7 +104,7 @@ class PreferenceForm extends React.Component {
     return (
       <form onSubmit={this.handleSubmit}>
         <label htmlFor='location-finder'>Search for your location here</label>
-        <LocationFinder sendData={this.getData} />
+        <LocationFinder sendData={this.getLocationData} />
         <label htmlFor='cuisine'>
           What cuisine?
           <select

--- a/project/frontend/src/components/PreferenceForm.js
+++ b/project/frontend/src/components/PreferenceForm.js
@@ -76,7 +76,6 @@ class PreferenceForm extends React.Component {
     currLocation['lat'] = this.props.history.location.currLocation.lat;
     currLocation['lng'] = this.props.history.location.currLocation.lng;
     this.setState({ currLocation });
-    console.log(this.state);
     this.props.history.push({
       pathname: '/match-results',
       state: this.state,

--- a/project/frontend/src/components/PreferenceForm.js
+++ b/project/frontend/src/components/PreferenceForm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import LocationFinder from './LocationFinder.js';
 
 import { Slider } from 'rsuite';
 
@@ -28,7 +27,6 @@ class PreferenceForm extends React.Component {
     };
     this.changeState = this.changeState.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.getLocationData = this.getLocationData.bind(this);
   }
 
   // Updates the state of the input element so it holds the chosen value.
@@ -40,9 +38,6 @@ class PreferenceForm extends React.Component {
       this.setState({ [event.target.name]: cuisineList });
     } else if (event.target.name === 'open') {
       this.setState({ [event.target.name]: event.target.checked });
-    } else if (event.target.name === 'currLocation' && event.target.value) {
-      field[event.target.id] = parseFloat(event.target.value);
-      this.setState({ [event.target.name]: field });
     } else {
       field['pref'] =
         event.target.name === 'diningExp'
@@ -56,10 +51,6 @@ class PreferenceForm extends React.Component {
     const field = this.state[attrName];
     field['weight'] = value;
     this.setState({ [attrName]: field });
-  }
-
-  getLocationData(data) {
-    this.setState({ currLocation: data.currLocation });
   }
 
   getSlider(attrName) {
@@ -81,6 +72,11 @@ class PreferenceForm extends React.Component {
 
   handleSubmit(event) {
     event.preventDefault();
+    const { currLocation } = this.state;
+    currLocation['lat'] = this.props.history.location.currLocation.lat;
+    currLocation['lng'] = this.props.history.location.currLocation.lng;
+    this.setState({ currLocation });
+    console.log(this.state);
     this.props.history.push({
       pathname: '/match-results',
       state: this.state,
@@ -103,8 +99,7 @@ class PreferenceForm extends React.Component {
     const prices = { Low: 1, Medium: 2, High: 3, 'Very High': 4 };
     return (
       <form onSubmit={this.handleSubmit}>
-        <label htmlFor='location-finder'>Search for your location here
-        <LocationFinder sendData={this.getLocationData} /></label>
+        <p>Your current location: {this.props.history.location.locationName}</p>
         <label htmlFor='cuisine'>
           What cuisine?
           <select

--- a/project/frontend/src/pages/HomePage.js
+++ b/project/frontend/src/pages/HomePage.js
@@ -4,12 +4,23 @@ import React, { useState } from 'react';
 
 import Modal from '../components/Modal.js';
 import PreferenceForm from '../components/PreferenceForm.js';
+import LocationFinder from '../components/LocationFinder';
 
 function HomePage(props) {
   const [isPreferenceFormOpen, setIsPreferenceFormOpen] = useState(false);
+  const [isLocationFormOpen, setIsLocationFormOpen] = useState(false);
 
   const togglePreferenceForm = () => {
     setIsPreferenceFormOpen((prev) => !prev);
+  };
+
+  const toggleLocationForm = () => {
+    setIsLocationFormOpen((prev) => !prev);
+  };
+
+  const handleClick = () => {
+    togglePreferenceForm();
+    toggleLocationForm();
   };
 
   return [
@@ -18,9 +29,13 @@ function HomePage(props) {
         <div id='welcome' className='column'>
           <h1 id='logo'>[LOGO]</h1>
           <h4>Discover your restaurant match</h4>
-          <button>Location</button>
+          <button onClick={toggleLocationForm}>Location</button>
           <div>
-            <button onClick={togglePreferenceForm}>Find My Match</button>
+            <button
+              disabled={!Boolean(props.history.location.currLocation)}
+              onClick={togglePreferenceForm}>
+              Find My Match
+            </button>
             <button>Swipe Match</button>
           </div>
         </div>
@@ -83,6 +98,20 @@ function HomePage(props) {
       top='64px'
       bottom='64px'>
       <PreferenceForm history={props.history} />
+    </Modal>,
+    <Modal
+      key='location-form'
+      open={isLocationFormOpen}
+      onDismiss={toggleLocationForm}
+      centerHorizontal={true}
+      top='64px'
+      bottom='64px'>
+      <LocationFinder sendData={(data) => props.history.push(data)} />
+      <button
+        disabled={!Boolean(props.history.location.currLocation)}
+        onClick={handleClick}>
+        Find my match
+      </button>
     </Modal>,
   ];
 }

--- a/project/frontend/src/pages/HomePage.js
+++ b/project/frontend/src/pages/HomePage.js
@@ -38,9 +38,7 @@ function HomePage(props) {
           <h4>Discover your restaurant match</h4>
           <button onClick={toggleLocationForm}>Location</button>
           <div>
-            <button
-              disabled={!locationName}
-              onClick={togglePreferenceForm}>
+            <button disabled={!locationName} onClick={togglePreferenceForm}>
               Find My Match
             </button>
             <button>Swipe Match</button>
@@ -104,10 +102,10 @@ function HomePage(props) {
       centerHorizontal={true}
       top='64px'
       bottom='64px'>
-      <PreferenceForm 
-        history={props.history} 
-        currLocation={currLocation} 
-        locationName={locationName} 
+      <PreferenceForm
+        history={props.history}
+        currLocation={currLocation}
+        locationName={locationName}
       />
     </Modal>,
     <Modal
@@ -118,9 +116,7 @@ function HomePage(props) {
       top='64px'
       bottom='64px'>
       <LocationFinder sendData={handleLocationData} />
-      <button
-        disabled={!locationName}
-        onClick={handleClick}>
+      <button disabled={!locationName} onClick={handleClick}>
         Find my match
       </button>
     </Modal>,

--- a/project/frontend/src/pages/HomePage.js
+++ b/project/frontend/src/pages/HomePage.js
@@ -9,6 +9,8 @@ import LocationFinder from '../components/LocationFinder';
 function HomePage(props) {
   const [isPreferenceFormOpen, setIsPreferenceFormOpen] = useState(false);
   const [isLocationFormOpen, setIsLocationFormOpen] = useState(false);
+  const [currLocation, setCurrLocation] = useState({});
+  const [locationName, setLocationName] = useState('');
 
   const togglePreferenceForm = () => {
     setIsPreferenceFormOpen((prev) => !prev);
@@ -24,7 +26,8 @@ function HomePage(props) {
   };
 
   const handleLocationData = (locationData) => {
-    props.history.push(locationData);
+    setCurrLocation(locationData.currLocation);
+    setLocationName(locationData.locationName);
   };
 
   return [
@@ -36,7 +39,7 @@ function HomePage(props) {
           <button onClick={toggleLocationForm}>Location</button>
           <div>
             <button
-              disabled={!Boolean(props.history.location.currLocation)}
+              disabled={!locationName}
               onClick={togglePreferenceForm}>
               Find My Match
             </button>
@@ -101,7 +104,11 @@ function HomePage(props) {
       centerHorizontal={true}
       top='64px'
       bottom='64px'>
-      <PreferenceForm history={props.history} />
+      <PreferenceForm 
+        history={props.history} 
+        currLocation={currLocation} 
+        locationName={locationName} 
+      />
     </Modal>,
     <Modal
       key='location-form'
@@ -112,7 +119,7 @@ function HomePage(props) {
       bottom='64px'>
       <LocationFinder sendData={handleLocationData} />
       <button
-        disabled={!Boolean(props.history.location.currLocation)}
+        disabled={!locationName}
         onClick={handleClick}>
         Find my match
       </button>

--- a/project/frontend/src/pages/HomePage.js
+++ b/project/frontend/src/pages/HomePage.js
@@ -23,10 +23,8 @@ function HomePage(props) {
     toggleLocationForm();
   };
 
-  const handleData = (data) => {
-    if (data) {
-      props.history.push(data);
-    }
+  const handleLocationData = (locationData) => {
+    props.history.push(locationData);
   };
 
   return [
@@ -112,7 +110,7 @@ function HomePage(props) {
       centerHorizontal={true}
       top='64px'
       bottom='64px'>
-      <LocationFinder sendData={handleData} />
+      <LocationFinder sendData={handleLocationData} />
       <button
         disabled={!Boolean(props.history.location.currLocation)}
         onClick={handleClick}>

--- a/project/frontend/src/pages/HomePage.js
+++ b/project/frontend/src/pages/HomePage.js
@@ -23,6 +23,12 @@ function HomePage(props) {
     toggleLocationForm();
   };
 
+  const handleData = (data) => {
+    if (data) {
+      props.history.push(data);
+    }
+  };
+
   return [
     <div key='home-page' className='container u-full-width'>
       <div className='row'>
@@ -106,7 +112,7 @@ function HomePage(props) {
       centerHorizontal={true}
       top='64px'
       bottom='64px'>
-      <LocationFinder sendData={(data) => props.history.push(data)} />
+      <LocationFinder sendData={handleData} />
       <button
         disabled={!Boolean(props.history.location.currLocation)}
         onClick={handleClick}>


### PR DESCRIPTION
Using Geocoder API for user to enter their current location.

Current functionality:
- text box shows up when user clicks on Location button (find match buttons are disabled until a location has been entered)
- when user clicks the submit "Find Location" button, if the location is found it is pushed to props.history
- if location isn't found it alerts the user
- When user submits their location, text shows the location that was found (example: if I enter "montgomery new jersey" and submit, we display "Montgomery, NJ, USA" back to the user so they can confirm it is the correct location)
- button that can access user's current location without having to enter anything